### PR TITLE
即使退出应用，某些手机上仍然在状态栏显示“YGOMobile正在运行”;

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.EXPAND_STATUS_BAR"/>
 
     <uses-sdk
         tools:overrideLibrary="com.toptoche.searchablespinnerlibrary"/>

--- a/mobile/src/main/res/layout/notification_view_duel_assistant.xml
+++ b/mobile/src/main/res/layout/notification_view_duel_assistant.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/notification_view_duel_assistant"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/imageViewIcon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentLeft="true"
+        android:layout_centerVertical="true"
+        android:src="@drawable/ic_icon"/>
+
+    <Button
+        android:id="@+id/buttonStopService"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:padding="15dp"
+        android:textColor="@color/colorAccent"
+        android:text="关闭"/>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toEndOf="@id/imageViewIcon"
+        android:layout_toRightOf="@id/imageViewIcon"
+        android:layout_toStartOf="@id/buttonStopService"
+        android:layout_toLeftOf="@id/buttonStopService"
+        android:layout_marginStart="5dp"
+        android:layout_marginEnd="5dp"
+        android:layout_centerVertical="true"
+        android:textSize="18sp"
+        android:text="决斗助手运行中" />
+
+</RelativeLayout>


### PR DESCRIPTION
改为明确的提示以及附带打开YGOMobile以及关闭“决斗助手服务”功能
注：layout文件中的文字需要更改以适配语言，以及美化（这个按钮贼丑(っ °Д °;)っ）；
按关闭结束服务，按其它地方打开YGOMobile

现在的效果大概是这样：
![image](https://user-images.githubusercontent.com/44423121/48254760-d8719980-e445-11e8-91a6-c195ea61d9d0.png)
