### PR TITLE
Could you please add the 7210 server back to serverlist?

### DIFF
--- a/mobile/assets/serverlist.xml
+++ b/mobile/assets/serverlist.xml
@@ -23,4 +23,11 @@
         <port>765</port>
         <keep>true</keep>
     </server>
+    <server>
+        <player-name>Knight of Hanoi</player-name>
+        <name>7210服务器</name>
+        <ip>222.73.218.25</ip>
+        <port>7210</port>
+        <keep>true</keep>
+    </server>
 </servers>


### PR DESCRIPTION
For over a half year player were complaining of having difficulty of duelling in 7210 server, because of the lack of 7210 server on YGOMobile's serverlist.
I don't think the update process of the server could be a problem. 7210 server may be better for some players, for it supports reconnection feature, as well as sending the replays after the whole match.
I checked for months about the traffic of 7210 server. After removal, the traffic fell from more than 100 to less than 30. I really don't want not being on the serverlist become a barrier of the players duelling in 7210 server. Please consider it again. Thanks!