### PR TITLE
Change chat domain

### DIFF
--- a/mobile/src/main/java/cn/garymb/ygomobile/ui/mycard/mcchat/management/ServiceManagement.java
+++ b/mobile/src/main/java/cn/garymb/ygomobile/ui/mycard/mcchat/management/ServiceManagement.java
@@ -215,7 +215,7 @@ public class ServiceManagement {
                 .setXmppDomain("mycard.moe")
                 .setKeystoreType(null)
                 .setSecurityMode(ConnectionConfiguration.SecurityMode.ifpossible)
-                .setHost("chat.mycard.moe")
+                .setHost("chat.moecube.com")
                 .build();
         con = new XMPPTCPConnection(config);
         return con;


### PR DESCRIPTION
The domain `chat.moecube.com` has ICP licenses, which we can put in to better line. Please use this.