### PR TITLE
Update game.cpp

### DIFF
--- a/Classes/gframe/game.cpp
+++ b/Classes/gframe/game.cpp
@@ -207,6 +207,7 @@ bool Game::Initialize(ANDROID_APP app, android::InitOptions *options) {
 	driver->setTextureCreationFlag(irr::video::ETCF_OPTIMIZED_FOR_QUALITY, true);
 
 	imageManager.SetDevice(device);
+	imageManager.ClearTexture();
 	if(!imageManager.Initial(workingDir))
 		return false;
 	// LoadExpansions only load zips, the other cdb databases are still loaded by getDBFiles


### PR DESCRIPTION
bug fix:
while game exits with abnormal behavior, tMap list won't be freed.