### PR TITLE
修改ot搜索

### DIFF
--- a/mobile/src/main/java/cn/garymb/ygomobile/loader/CardSearchInfo.java
+++ b/mobile/src/main/java/cn/garymb/ygomobile/loader/CardSearchInfo.java
@@ -248,7 +248,7 @@ public class CardSearchInfo implements ICardFilter{
         }
         if (ot > CardOt.ALL.getId()) {
             if (ot == CardOt.NO_EXCLUSIVE.getId()) {
-                if (card.Ot == CardOt.OCG.getId() || card.Ot == CardOt.TCG.getId()) {
+                if (card.Ot == CardOt.OCG.getId() || card.Ot == CardOt.TCG.getId() || card.Ot == CardOt.CUSTOM.getId()) {
                     return false;
                 }
             } else if (ot == CardOt.OCG.getId() || ot == CardOt.TCG.getId()) {


### PR DESCRIPTION
因为在搜索无独有卡时，自定义卡片会被一同列出，又因为已有单独列出自定义卡片的选项，且在装有自定义卡片后想单独搜索原版卡片十分不便，故作此修改