### PR TITLE
Link箭头应该正确的在怪物Reset的时候重置（且不应该在Search的时候重置）

### DIFF
--- a/mobile/src/main/java/cn/garymb/ygomobile/ui/cards/CardSearcher.java
+++ b/mobile/src/main/java/cn/garymb/ygomobile/ui/cards/CardSearcher.java
@@ -587,7 +587,6 @@ public class CardSearcher implements View.OnClickListener {
                     .build();
             Log.i(TAG, searchInfo.toString());
             mICardSearcher.search(searchInfo);
-            lineKey = 0;
         }
     }
 
@@ -620,6 +619,7 @@ public class CardSearcher implements View.OnClickListener {
         reset(attributeSpinner);
         atkText.setText(null);
         defText.setText(null);
+        lineKey = 0;
     }
 
     public interface CallBack {


### PR DESCRIPTION
案例：点下箭头，点击重置，LinkKey仍然在，只能搜索link下箭头的怪兽