### PR TITLE
[FIXED] Error in the indicator of new pre-released cards

### DIFF
--- a/mobile/assets/pt/serverlist.xml
+++ b/mobile/assets/pt/serverlist.xml
@@ -8,7 +8,7 @@
         <desc>Servidor mycard dentro das cartas de expansões</desc>
         <ip>mygo.superpre.pro</ip>
         <port>888</port>
-        <keep>verdadeiro</keep>
+        <keep>true</keep>
     </server>
     <server>
         <player-name>Cavaleiro de Hanoi</player-name>
@@ -16,7 +16,7 @@
         <desc>Servidor mycard dentro das cartas de expansões</desc>
         <ip>mygo.superpre.pro</ip>
         <port>888</port>
-        <keep>verdadeiro</keep>
+        <keep>true</keep>
     </server>
     <server>
         <player-name>Cavaleiro de Hanoi</player-name>
@@ -24,7 +24,7 @@
         <desc>Ambientes TCG</desc>
         <ip>server.evolutionygo.com</ip>
         <port>7711</port>
-        <keep>verdadeiro</keep>
+        <keep>true</keep>
     </server>
      <server>
         <player-name>Cavaleiro de Hanoi</player-name>
@@ -32,7 +32,7 @@
         <desc>TCG</desc>
         <ip>koishi.momobako.com</ip>
         <port>1311</port>
-        <keep>verdadeiro</keep>
+        <keep>true</keep>
     </server>
     <server>
         <player-name>Cavaleiro de Hanoi</player-name>
@@ -40,7 +40,7 @@
         <desc>OCG</desc>
         <ip>koishi.momobako.com</ip>
         <port>7210</port>
-        <keep>verdadeiro</keep>
+        <keep>true</keep>
     </server>
     <server>
         <player-name>Cavaleiro de Hanoi</player-name>
@@ -48,7 +48,7 @@
         <desc>Tempo de atualização desconhecido</desc>
         <ip>s1.ygo233.com</ip>
         <port>233</port>
-        <keep>verdadeiro</keep>
+        <keep>true</keep>
     </server>
     <server>
         <player-name>Cavaleiro de Hanoi</player-name>
@@ -56,7 +56,7 @@
         <desc>Usar deck aleatório para duelar</desc>
         <ip>2333.duelstart.com</ip>
         <port>2333</port>
-        <keep>verdadeiro</keep>
+        <keep>true</keep>
     </server>
     <server>
         <player-name>Cavaleiro de Hanoi</player-name>
@@ -64,6 +64,6 @@
         <desc>Construir novo deck para duelar</desc>
         <ip>2pick.moecube.com</ip>
         <port>765</port>
-        <keep>verdadeiro</keep>
+        <keep>true</keep>
     </server>
 </servers>

--- a/mobile/src/main/java/cn/garymb/ygomobile/utils/ServerUtil.java
+++ b/mobile/src/main/java/cn/garymb/ygomobile/utils/ServerUtil.java
@@ -58,7 +58,7 @@ public class ServerUtil {
         String oldVer = SharedPreferenceUtil.getExpansionDataVer();
         LogUtil.i(TAG, "server util, old pre-card version:" + oldVer);
         String URL_DATAVER = URL_CN_DATAVER;
-        URL_DATAVER = (AppsSettings.get().getDataLanguage() == AppsSettings.languageEnum.Chinese.code) ? URL_CN_DATAVER : "https://github.com/DaruKani/TransSuperpre/blob/main/" + getLanguageId() + "/version.txt";
+        URL_DATAVER = (AppsSettings.get().getDataLanguage() == AppsSettings.languageEnum.Chinese.code) ? URL_CN_DATAVER : "https://raw.githubusercontent.com/ElderLich/TransSuperpre/refs/heads/main/" + getLanguageId() + "/version.txt";
         OkhttpUtil.get(URL_DATAVER, new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
@@ -317,14 +317,14 @@ public class ServerUtil {
     public static String downloadUrl() {
         String url;
         url = (AppsSettings.get().getDataLanguage() == AppsSettings.languageEnum.Chinese.code)
-                ? URL_SUPERPRE_CN_FILE : "https://raw.githubusercontent.com/DaruKani/TransSuperpre/refs/heads/main/" + getLanguageId() + "/ygopro-super-pre.ypk";
+                ? URL_SUPERPRE_CN_FILE : "https://raw.githubusercontent.com/ElderLich/TransSuperpre/refs/heads/main/" + getLanguageId() + "/ygopro-super-pre.ypk";
         return url;
     }
 
     public static String preCardListJson() {
         String json;
         json = (AppsSettings.get().getDataLanguage() == AppsSettings.languageEnum.Chinese.code)
-                ? URL_PRE_CARD : "https://raw.githubusercontent.com/DaruKani/TransSuperpre/refs/heads/main/" + getLanguageId() + "/test-release.json";
+                ? URL_PRE_CARD : "https://raw.githubusercontent.com/ElderLich/TransSuperpre/refs/heads/main/" + getLanguageId() + "/test-release.json";
         return json;
     }
     public enum ExCardState {

--- a/mobile/src/main/res/values-es/strings.xml
+++ b/mobile/src/main/res/values-es/strings.xml
@@ -79,7 +79,7 @@
     <string name="settings_game_immersive_mode">Optimizar si su resolución no es 16:9</string>
     <string name="settings_game_opengl">OpenGL</string>
     <string name="settings_game_avatar">Imagen de Perfil</string>
-    <string name="tip_download_ex">¡Hay nuevas cartas pre-lanzadas disponibles!</string>
+    <string name="tip_download_ex">¡Nuevas Pre-lanzadas!</string>
     <string name="restart_app">¡Por favor, reinicie la aplicación!</string>
     <string-array name="opengl_version">
         <item>OpenGL ES 1.X</item>


### PR DESCRIPTION
When we open the apk in the download button for pre-released cards we notice an announcement that tells us that there are new cards available.

Expected Result: we press the button, we download the cards and this announcement disappears until new cards are released or some change is made in the database of the same.

Actual Result: we press the button, we download the cards and this announcement persists so we will always see the sign that there are or are not new cards to download.

Possible Solution: it was detected that in the game code the reference to the git of the cards was incorrectly declared so where it says "github.com" we must put "raw.githubusercontent.com"