### PR TITLE
update Duel.LoadScript

### DIFF
--- a/Classes/ocgcore/libduel.cpp
+++ b/Classes/ocgcore/libduel.cpp
@@ -13,6 +13,8 @@
 #include "group.h"
 #include "ocgapi.h"
 
+#ifdef _IRR_ANDROID_PLATFORM_
+
 int32_t scriptlib::duel_load_script(lua_State *L) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_STRING, 1);
@@ -23,6 +25,10 @@ int32_t scriptlib::duel_load_script(lua_State *L) {
 	lua_pushboolean(L, pduel->lua->load_script(filename));
 	return 1;
 }
+
+#endif
+
+
 
 int32_t scriptlib::duel_enable_global_flag(lua_State *L) {
 	check_param_count(L, 1);
@@ -4850,9 +4856,9 @@ int32_t scriptlib::duel_majestic_copy(lua_State *L) {
 }
 
 static const struct luaL_Reg duellib[] = {
-	//For DIY
+	#ifdef _IRR_ANDROID_PLATFORM_
 	{ "LoadScript", scriptlib::duel_load_script },
-	//
+	#endif
 	
 	{ "EnableGlobalFlag", scriptlib::duel_enable_global_flag },
 	{ "GetLP", scriptlib::duel_get_lp },

--- a/Classes/ocgcore/libduel.cpp
+++ b/Classes/ocgcore/libduel.cpp
@@ -13,6 +13,17 @@
 #include "group.h"
 #include "ocgapi.h"
 
+int32_t scriptlib::duel_load_script(lua_State *L) {
+	check_param_count(L, 1);
+	check_param(L, PARAM_TYPE_STRING, 1);
+	duel* pduel = interpreter::get_duel_info(L); 
+	const char* pstr = lua_tostring(L, 1);
+	char filename[64];
+	sprintf(filename, "./script/%s", pstr);
+	lua_pushboolean(L, pduel->lua->load_script(filename));
+	return 1;
+}
+
 int32_t scriptlib::duel_enable_global_flag(lua_State *L) {
 	check_param_count(L, 1);
 	int32_t flag = (int32_t)lua_tointeger(L, 1);
@@ -4839,6 +4850,10 @@ int32_t scriptlib::duel_majestic_copy(lua_State *L) {
 }
 
 static const struct luaL_Reg duellib[] = {
+	//For DIY
+	{ "LoadScript", scriptlib::duel_load_script },
+	//
+	
 	{ "EnableGlobalFlag", scriptlib::duel_enable_global_flag },
 	{ "GetLP", scriptlib::duel_get_lp },
 	{ "SetLP", scriptlib::duel_set_lp },

--- a/Classes/ocgcore/scriptlib.h
+++ b/Classes/ocgcore/scriptlib.h
@@ -29,6 +29,9 @@ public:
 	static int32_t check_param_count(lua_State* L, int32_t count);
 	static int32_t check_action_permission(lua_State* L);
 
+	//For DIY
+	static int32_t duel_load_script(lua_State *L);
+
 	//card lib
 	static int32_t card_get_code(lua_State *L);
 	static int32_t card_get_origin_code(lua_State *L);

--- a/Classes/ocgcore/scriptlib.h
+++ b/Classes/ocgcore/scriptlib.h
@@ -29,9 +29,10 @@ public:
 	static int32_t check_param_count(lua_State* L, int32_t count);
 	static int32_t check_action_permission(lua_State* L);
 
-	//For DIY
+	#ifdef _IRR_ANDROID_PLATFORM_
 	static int32_t duel_load_script(lua_State *L);
-
+	#endif
+	
 	//card lib
 	static int32_t card_get_code(lua_State *L);
 	static int32_t card_get_origin_code(lua_State *L);


### PR DESCRIPTION
加入了Duel.LoadScript()， 用于在dofile()被禁止后重新提供调库接口，（已进行过自测）